### PR TITLE
fixed check for VMs not encrypted with CSEK

### DIFF
--- a/plugins/google/compute/csekEncryptionEnabled.js
+++ b/plugins/google/compute/csekEncryptionEnabled.js
@@ -78,7 +78,7 @@ module.exports = {
     
                     if (disk.creationTimestamp &&
                         disk.diskEncryptionKey &&
-                        Object.keys(disk.diskEncryptionKey) &&
+                        Object.keys(disk.diskEncryptionKey).includes('sha256') &&
                         Object.keys(disk.diskEncryptionKey).length) {
                         helpers.addResult(results, 0,
                             'CSEK Encryption is enabled for disk', region, resource);


### PR DESCRIPTION
Added a check for string sha256 in the diskEncryptionKey property to correctly  find VM disks not encrypted with CSEK